### PR TITLE
Bulk rendering w/ SpatialiteCatalog

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,41 @@
+FROM quay.io/mojodna/gdal:trunk
+MAINTAINER Seth Fitzsimmons <seth@mojodna.net>
+
+ARG http_proxy
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV GDAL_CACHEMAX 512
+ENV GDAL_DISABLE_READDIR_ON_OPEN TRUE
+ENV GDAL_HTTP_MERGE_CONSECUTIVE_RANGES YES
+ENV VSI_CACHE TRUE
+# tune this according to how much memory is available
+ENV VSI_CACHE_SIZE 536870912
+# override this accordingly; should be 2-4x $(nproc)
+ENV WEB_CONCURRENCY 4
+
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cython \
+    git \
+    python-dev \
+    python-pip \
+    python-pyspatialite \
+    python-setuptools \
+    python-wheel \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/marblecutter
+
+COPY requirements-tools.txt /opt/marblecutter/
+COPY requirements.txt /opt/marblecutter/
+
+RUN pip install -U pip numpy && \
+  pip install -r requirements-tools.txt && \
+  rm -rf /root/.cache
+
+COPY tilezen /opt/marblecutter/tilezen

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,5 +30,27 @@ services:
       - POSTGRES_DB=elevation
     volumes:
       - pgdata:/var/lib/postgresql/data
+  tools:
+    build:
+      context: .
+      dockerfile: Dockerfile.tools
+    depends_on:
+      - postgis
+    environment:
+      - DATABASE_URL=postgis://mapzen:mapzen@postgis/elevation
+      - PYTHONPATH=.
+      - AWS_REQUEST_PAYER=requester
+      - CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.vrt,.tif,.ovr,.msk
+      # - CPL_CURL_VERBOSE=YES
+      - GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES
+      - GDAL_HTTP_VERSION=2
+      - WEB_CONCURRENCY=10
+    env_file: .env
+    volumes:
+      - .:/opt/marblecutter/
+      - ../marblecutter/marblecutter:/usr/local/lib/python2.7/dist-packages/marblecutter
+      - ../marblecutter/marblecutter:/usr/local/lib/python3.5/dist-packages/marblecutter
+    links:
+      - postgis
 volumes:
   pgdata:

--- a/examples/render_pyramid_to_mbtiles.py
+++ b/examples/render_pyramid_to_mbtiles.py
@@ -1,89 +1,32 @@
-# noqa
 # coding=utf-8
 from __future__ import print_function
 
 import argparse
 import logging
 import os
-import random
-import time
-from functools import wraps
-from multiprocessing.dummy import Pool
-
-from shapely import wkb
-from shapely.geometry import box
-
-import boto3
-import botocore
-import mercantile
-import psycopg2
-import psycopg2.extras
 import sqlite3
-from marblecutter import tiling
-from marblecutter.formats import PNG, GeoTIFF
-from marblecutter.sources import MemoryAdapter
+
+import mercantile
+from marblecutter import get_resolution_in_meters, tiling
+from marblecutter.catalogs import WGS84_CRS
+from marblecutter.catalogs.postgis import PostGISCatalog
+from marblecutter.formats.png import PNG
 from marblecutter.stats import Timer
-from marblecutter.transformations import Normal, Terrarium
+from marblecutter.transformations import Image
+from marblecutter.utils import Bounds
 from mercantile import Tile
+from tilezen.catalogs import SpatialiteCatalog
 
 logging.basicConfig(level=logging.INFO)
-# Quieting boto messages down a little
-logging.getLogger('boto3.resources.action').setLevel(logging.WARNING)
 logging.getLogger('botocore').setLevel(logging.WARNING)
-logging.getLogger('marblecutter').setLevel(logging.WARNING)
 logging.getLogger('marblecutter.mosaic').setLevel(logging.WARNING)
-logging.getLogger('marblecutter.sources').setLevel(logging.WARNING)
 logger = logging.getLogger('batchtiler')
 
 if os.environ.get('VERBOSE'):
     logger.setLevel(logging.DEBUG)
 
-POOL_SIZE = 12
-POOL = Pool(POOL_SIZE)
-MBTILES_POOL = Pool(1)
-OVERWRITE = os.environ.get('OVERWRITE_EXISTING_OBJECTS') == 'true'
-
-GEOTIFF_FORMAT = GeoTIFF()
+IMAGE_TRANSFORMATION = Image()
 PNG_FORMAT = PNG()
-NORMAL_TRANSFORMATION = Normal()
-TERRARIUM_TRANSFORMATION = Terrarium()
-
-RENDER_COMBINATIONS = [
-    ("normal", NORMAL_TRANSFORMATION, PNG_FORMAT, ".png"),
-    ("terrarium", TERRARIUM_TRANSFORMATION, PNG_FORMAT, ".png"),
-    ("geotiff", None, GEOTIFF_FORMAT, ".tif"),
-]
-
-
-# From https://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
-def retry(ExceptionToCheck,
-          tries=4,
-          delay=3,
-          backoff=2,
-          max_delay=60,
-          logger=None):
-    def deco_retry(f):
-        @wraps(f)
-        def f_retry(*args, **kwargs):
-            mtries, mdelay = tries, delay
-            while mtries > 1:
-                try:
-                    return f(*args, **kwargs)
-                except ExceptionToCheck, e:
-                    msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
-                    if logger:
-                        logger.exception(msg)
-                    else:
-                        print(msg)
-                    time.sleep(mdelay)
-                    mtries -= 1
-                    mdelay *= backoff
-                    mdelay = min(mdelay, max_delay)
-            return f(*args, **kwargs)
-
-        return f_retry  # true decorator
-
-    return deco_retry
 
 
 class MbtilesOutput(object):
@@ -146,7 +89,7 @@ class MbtilesOutput(object):
         if row is None or zoom is None:
             raise TypeError("zoom and row cannot be null")
 
-        return (2 ** zoom) - 1 - row
+        return (2**zoom) - 1 - row
 
     def add_metadata(self, name, value):
         self._cur.execute("""
@@ -155,12 +98,7 @@ class MbtilesOutput(object):
             ) VALUES (
                 ?, ?
             );
-            """,
-            (
-                name,
-                value,
-            )
-        )
+            """, (name, value, ))
 
     def open(self):
         self._conn = sqlite3.connect(self._filename)
@@ -175,100 +113,82 @@ class MbtilesOutput(object):
             ) VALUES (
                 ?, ?, ?, ?
             );
-            """,
-            (
-                tile.z,
-                tile.x,
-                self._flip_y(tile.z, tile.y),
-                sqlite3.Binary(data),
-            )
-        )
+            """, (tile.z, tile.x, self._flip_y(tile.z, tile.y),
+                  sqlite3.Binary(data), ))
 
     def close(self):
         self._conn.commit()
         self._conn.close()
 
 
-def build_source_index(tile, min_zoom, max_zoom):
-    source_cache = MemoryAdapter()
-    bbox = box(*mercantile.bounds(tile))
+def sources_for_tile(tile, catalog, min_zoom=None, max_zoom=None):
+    """Render a tile's source footprints."""
+    bounds = Bounds(mercantile.bounds(tile), WGS84_CRS)
+    shape = (256, 256)
+    resolution = get_resolution_in_meters(bounds, shape)
 
-    database_url = os.environ.get('DATABASE_URL')
-
-    with psycopg2.connect(database_url) as conn:
-        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
-            cur.execute("""
-                SELECT
-                    filename, resolution, source, url,
-                    min_zoom, max_zoom, priority, approximate_zoom,
-                    wkb_geometry
-                FROM
-                    footprints
-                WHERE
-                    ST_Intersects(
-                        wkb_geometry,
-                        ST_GeomFromText(%s, 4326)
-                    )
-                    AND min_zoom <= %s
-                    AND max_zoom >= %s
-                    AND enabled = true
-                """, (bbox.to_wkt(), min_zoom, max_zoom))
-
-            logger.info("Found %s sources for tile %s, zoom %s-%s",
-                cur.rowcount, tile, min_zoom, max_zoom)
-
-            if not cur.rowcount:
-                raise ValueError("No sources found for this tile")
-
-            for row in cur:
-                row = dict(row)
-                shape = wkb.loads(row.pop('wkb_geometry').decode('hex'))
-                source_cache.add_source(shape, row)
-
-    return source_cache
+    return catalog.get_sources(
+        bounds,
+        resolution,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        include_geometries=True)
 
 
-def render_tile_exc_wrapper(tile, sources, output):
+def build_catalog(tile, min_zoom, max_zoom):
+    upstream_catalog = PostGISCatalog(table="imagery")
+    catalog = SpatialiteCatalog()
+
+    for source in sources_for_tile(
+            tile, upstream_catalog, min_zoom=min_zoom, max_zoom=max_zoom):
+        catalog.add_source(source)
+
+    return catalog
+
+
+def render_tile_exc_wrapper(tile, catalog, output):
     try:
-        render_tile(tile, sources, output)
+        render_tile(tile, catalog, output)
     except Exception:
         logger.exception('Error while processing tile %s', tile)
         raise
 
 
-def render_tile(tile, sources, output):
-    for (type, transformation, format, ext) in RENDER_COMBINATIONS:
+def render_tile(tile, catalog, output):
+    with Timer() as t:
+        (headers, data) = tiling.render_tile(
+            tile,
+            catalog,
+            format=PNG_FORMAT,
+            transformation=IMAGE_TRANSFORMATION)
 
-        with Timer() as t:
-            (headers, data) = tiling.render_tile(
-                tile, sources, format=format, transformation=transformation)
+    logger.debug(
+        '(%02d/%06d/%06d) Took %0.3fs to render tile (%s bytes), Source: %s, Timers: %s',
+        tile.z,
+        tile.x,
+        tile.y,
+        t.elapsed,
+        len(data),
+        headers.get('X-Imagery-Sources'),
+        headers.get('X-Timers'), )
 
-        logger.debug(
-            '(%02d/%06d/%06d) Took %0.3fs to render %s tile (%s bytes), Source: %s, Timers: %s',
-            tile.z, tile.x, tile.y, t.elapsed, type,
-            len(data),
-            headers.get('X-Imagery-Sources'),
-            headers.get('X-Timers'),
-        )
-
-        MBTILES_POOL.apply_async(
-            write_to_mbtiles,
-            args=[type, tile, headers, data, output]
-        )
+    write_to_mbtiles(tile, headers, data, output)
 
 
-def write_to_mbtiles(type, tile, headers, data, output):
+def write_to_mbtiles(tile, headers, data, output):
     try:
         with Timer() as t:
-            outputter = output.get(type)
+            outputter = output
             outputter.add_tile(tile, data)
 
         logger.debug(
-            '(%02d/%06d/%06d) Took %0.3fs to write %s tile to mbtiles://%s',
-            tile.z, tile.x, tile.y, t.elapsed, type,
-            outputter._filename,
-        )
-    except:
+            '(%02d/%06d/%06d) Took %0.3fs to write tile to mbtiles://%s',
+            tile.z,
+            tile.x,
+            tile.y,
+            t.elapsed,
+            outputter._filename, )
+    except Exception:
         logger.exception("Problem writing to mbtiles")
 
 
@@ -280,9 +200,9 @@ def queue_tile(tile, max_zoom, sources, output):
             queue_tile(child, max_zoom, sources, output)
 
 
-def queue_render(tile, sources, output):
+def queue_render(tile, catalog, output):
     logger.debug('Enqueueing render for tile %s', tile)
-    POOL.apply_async(render_tile_exc_wrapper, args=[tile, sources, output])
+    render_tile_exc_wrapper(tile, catalog, output)
 
 
 if __name__ == "__main__":
@@ -296,25 +216,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
     root = Tile(args.x, args.y, args.zoom)
 
-    logger.info('Caching sources for root tile %s to zoom %s',
-                root, args.max_zoom)
+    logger.info('Caching sources for root tile %s to zoom %s', root,
+                args.max_zoom)
 
-    source_index = build_source_index(root, args.zoom, args.max_zoom)
+    catalog = build_catalog(root, args.zoom, args.max_zoom)
 
-    output = {}
-    for type, _, _, _ in RENDER_COMBINATIONS:
-        fname = '{}-{}.mbtiles'.format(args.mbtiles_prefix, type)
-        output[type] = MbtilesOutput(fname)
-        output[type].open()
+    fname = '{}.mbtiles'.format(args.mbtiles_prefix)
+    output = MbtilesOutput(fname)
+    output.open()
 
-    logger.info('Running %s processes', POOL_SIZE)
+    queue_tile(root, args.max_zoom, catalog, output)
 
-    queue_tile(root, args.max_zoom, source_index, output)
+    logger.info('Done processing root pyramid %s to zoom %s', root,
+                args.max_zoom)
 
-    POOL.close()
-    POOL.join()
-    logger.info('Done processing root pyramid %s to zoom %s',
-                root, args.max_zoom)
-
-    for outputter in output.values():
-        outputter.close()
+    output.close()

--- a/examples/render_pyramid_to_mbtiles.py
+++ b/examples/render_pyramid_to_mbtiles.py
@@ -121,6 +121,7 @@ class MbtilesOutput(object):
         self._conn.close()
 
 
+# TODO fold this upstream, e.g. footprints.something
 def sources_for_tile(tile, catalog, min_zoom=None, max_zoom=None):
     """Render a tile's source footprints."""
     bounds = Bounds(mercantile.bounds(tile), WGS84_CRS)

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+pyspatialite

--- a/tilezen/catalogs.py
+++ b/tilezen/catalogs.py
@@ -89,7 +89,7 @@ INSERT INTO footprints (
                   json.dumps(source.meta), json.dumps(source.recipes),
                   json.dumps(source.band_info), None
                   if source.acquired_at is None else
-                  dateutil.parser.parse(source.acquired_at).isoformat(),
+                  dateutil.parser.parse(str(source.acquired_at)).isoformat(),
                   json.dumps(source.geom)))
 
             self.conn.commit()

--- a/tilezen/catalogs.py
+++ b/tilezen/catalogs.py
@@ -254,7 +254,7 @@ LIMIT 1
 
                     urls.add(url)
 
-                if count == 0:
+                if count == 0 or uncovered is None:
                     break
 
         except Exception as e:

--- a/tilezen/catalogs.py
+++ b/tilezen/catalogs.py
@@ -243,10 +243,16 @@ LIMIT 1
                 count = 0
                 for record in cursor:
                     count += 1
-                    yield Source(*record[:-1])
+                    (url, source, res, band_info, meta, recipes, acquired_at,
+                     band, priority, coverage, geom, uncovered) = record
 
-                    urls.add(record[0])
-                    uncovered = record[-1]
+                    yield Source(url, source, res,
+                                 json.loads(band_info),
+                                 json.loads(meta),
+                                 json.loads(recipes), acquired_at, band,
+                                 priority, coverage)
+
+                    urls.add(url)
 
                 if count == 0:
                     break

--- a/tilezen/catalogs.py
+++ b/tilezen/catalogs.py
@@ -15,58 +15,6 @@ Infinity = float("inf")
 LOG = logging.getLogger(__name__)
 
 
-class MemoryCatalog(Catalog):
-    def __init__(self):
-        self._sources = []
-
-    def add_source(self, geometry, attributes):
-        self._sources.append((geometry, attributes))
-
-    def get_sources(self, bounds, resolution):
-        from shapely.geometry import box
-
-        bounds, bounds_crs = bounds
-
-        results = []
-        zoom = get_zoom(max(resolution))
-        ((left, right), (bottom, top)) = warp.transform(
-            bounds_crs, WGS84_CRS, bounds[::2], bounds[1::2])
-        bounds_geom = box(left, bottom, right, top)
-        bounds_centroid = bounds_geom.centroid
-
-        # Filter by zoom level and intersecting geometries
-        for candidate in self._sources:
-            (geom, attr) = candidate
-            if attr['min_zoom'] <= zoom < attr['max_zoom'] and \
-               geom.intersects(bounds_geom):
-                results.append(candidate)
-
-        # Sort by resolution and centroid distance
-        results = sorted(
-            results,
-            key=lambda (geom, attr): (
-                attr['priority'],
-                int(attr['resolution']),
-                bounds_centroid.distance(geom.centroid),
-            )
-        )
-
-        # Remove duplicate URLs
-        # From https://stackoverflow.com/a/480227
-        seen = set()
-        seen_add = seen.add
-        results = [
-            x for x in results
-            if not (x[1]['url'] in seen or seen_add(x[1]['url']))
-        ]
-
-        # Pick only the attributes we care about
-        results = [(a['url'], a['source'], a['resolution'])
-                   for (_, a) in results]
-
-        return results
-
-
 class SpatialiteCatalog(Catalog):
     def __init__(self):
         self.conn = spatialite.connect(":memory:")

--- a/tilezen/skadi.py
+++ b/tilezen/skadi.py
@@ -33,14 +33,14 @@ def _parse_skadi_tile(tile_name):
     return None
 
 
-def render_tile(tile, source_provider):
+def render_tile(tile, catalog):
     """Render a tile into gzipped HGT."""
     bounds = _bbox(*_parse_skadi_tile(tile))
 
     return render(
         (bounds, SKADI_CRS),
-        source_provider,
         SHAPE,
         SKADI_CRS,
+        catalog=catalog,
         data_band_count=1,
         format=SKADI_FORMAT)


### PR DESCRIPTION
An in-memory `SpatialiteCatalog` can be initialized from a list of `Source`s (produced by another catalog, locally (`PostGISCatalog`) or remote (`RemoteCatalog`)).

This adapts the bulk MBTiles renderer to use it in place of `MemoryCatalog`.

Multi-threaded pooling has been removed due to the use of SQLite by both the MBTiles output and `SpatialiteCatalog`.